### PR TITLE
feat: add travis test and auto-pull-request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-apache-tomcat-*-src.tar.gz
 

--- a/.release/Dockerfile
+++ b/.release/Dockerfile
@@ -1,0 +1,9 @@
+FROM centos
+
+RUN yum install -y epel-release \
+ && yum install -y git tito rpm-build rpmdevtools \
+ && yum clean all
+
+RUN git config --global user.email "travis@travis-ci.org" \
+ && git config --global user.name "Travis CI"
+

--- a/.release/create-pr-on-new-version.sh
+++ b/.release/create-pr-on-new-version.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -ex
+
+if [ -z "$GITHUB_USER" ]; then
+  echo "Env var GITHUB_USER not defined and needed to git push the new version."
+  exit -1
+fi
+
+if [ -z "$GITHUB_TOKEN" ]; then
+  echo "Env var GITHUB_TOKEN not defined and needed to git push the new version."
+  exit -1
+fi
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/.."
+MAJOR=`grep "%global major_version" $DIR/tomcat.spec |sed 's/.* //g' `
+MINOR=`grep "%global minor_version" $DIR/tomcat.spec |sed 's/.* //g' `
+RELEASE=`grep "Release:" $DIR/tomcat.spec |sed 's/Release: *\([0-9]*\).*/\1/g'`
+
+echo "Scrap tomcat website and fetch the version"
+MICRO=`curl -s http://www.apache.org/dist/tomcat/tomcat-$MAJOR/ |grep -e "<a href=\"v[0-9]\.$MINOR" |sed "s#.*v$MAJOR\.$MINOR\.\([0-9]*\).*#\1#g" |head -n 1`
+VERSION="$MAJOR.$MINOR.$MICRO"
+
+echo "Update specfile with new version $VERSION"
+sed -i "s/%global micro_version .*/%global micro_version $MICRO/g" $DIR/tomcat.spec
+
+echo "Check if version $VERSION is already commited"
+curl -s -f --user "$GITHUB_USER:$GITHUB_TOKEN" https://api.github.com/repos/$TRAVIS_REPO_SLUG/branches |grep name | grep "v$VERSION" && exit 0
+git diff --exit-code && exit 0
+
+echo "Download new sources"
+rm -f *.tar.gz
+docker build -t rpmbuilder .release/
+docker run -w /mnt -it -v `pwd`:/mnt rpmbuilder spectool -g *.spec
+md5sum *.tar.gz > sources
+git add -A
+
+echo "Create branch v$VERSION"
+git checkout -b "v$VERSION"
+git commit -am "Update to $VERSION"
+
+echo "Commit changelog"
+docker run -w /mnt -it -v `pwd`:/mnt rpmbuilder tito tag --accept-auto-changelog --keep-version
+
+echo "Push branch v$VERSION"
+NAME=`git remote -v |sed 's#.*/##'|sed 's/ .*//g'|sed 's/\.git//g'|head -n1` 
+git remote set-url origin "https://$GITHUB_USER:$GITHUB_TOKEN@github.com/$TRAVIS_REPO_SLUG.git"
+git push --set-upstream origin "v$VERSION"
+
+echo "Create new Merge Request"
+curl -s -f --user "$GITHUB_USER:$GITHUB_TOKEN" --request POST --data "{ \"title\": \"New version $VERSION\", \"body\": \"A new release is available $VERSION\n\nOnce merged don't forget to create the tag \`tomcat-$VERSION-$RELEASE\`\", \"head\": \"v$VERSION\", \"base\": \"$TRAVIS_BRANCH\" }" https://api.github.com/repos/$TRAVIS_REPO_SLUG/pulls

--- a/.test/Dockerfile
+++ b/.test/Dockerfile
@@ -1,0 +1,12 @@
+FROM $OS
+
+RUN yum install -y mock rpm-build rpmdevtools \
+ && yum clean all
+
+ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh /usr/bin/
+
+RUN chmod +x /usr/bin/wait-for-it.sh
+
+ADD entrypoint.sh /tmp/entrypoint.sh
+
+ENTRYPOINT ["/tmp/entrypoint.sh"]

--- a/.test/entrypoint.sh
+++ b/.test/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -ex
+
+echo "Build SRPM"
+chown root. *
+rpmbuild -bs *.spec
+
+echo "Build RPM"
+yum-builddep -y *.spec
+rpmbuild -ba *.spec
+
+echo "Install RPM"
+yum install -y  /root/rpmbuild/RPMS/noarch/*.rpm
+
+echo "Start Tomcat"
+/usr/libexec/tomcat/server start &
+
+echo "Wait for Tomcat to be ready"
+wait-for-it.sh localhost:8080 -- echo "Tomcat is up"
+
+curl -s -I -L localhost:8080/examples/servlets |grep 200
+curl -s -I -L localhost:8080/examples/jsp |grep 200
+curl -s -I -L localhost:8080/examples/websocket |grep 200

--- a/.test/test.sh
+++ b/.test/test.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -ex
+
+# Support both centos (yum) and Fedora (dnf)
+sed -i "s/FROM .*/FROM $OS/g" .test/Dockerfile
+if [[ "$OS" =~ ^fedora.* ]]; then
+  sed -i "s/yum-/dnf /g" .test/*
+  sed -i "s/yum/dnf/g" .test/*
+fi
+
+# Travis is using Ubuntu, use Docker to get RPM build tools
+docker build -t rpmbuilder .test/
+docker run -w /root/rpmbuild/SOURCES/ -it -v `pwd`:/root/rpmbuild/SOURCES/ rpmbuilder

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+sudo: required
+
+services:
+  - docker
+
+env:
+ matrix:
+   - OS=centos:7
+   - OS=fedora:25
+   - OS=fedora:26
+#   - OS=fedora:rawhide
+
+script: if [ $TRAVIS_EVENT_TYPE != "cron" ]; then .test/test.sh; fi
+
+jobs:
+  include:
+    - stage: create_pr_on_new_version
+      if: type = cron
+      script: .release/create-pr-on-new-version.sh


### PR DESCRIPTION
Hello Coty,

In my company, I am packaging my own version of Tomcat on RHEL but I would prefer to rely on a package managed by an OpenSource community instead of reinventing the wheel.

Users and security people are always asking for the latest version of Tomcat.

I did one thing internally that may interest you. It's a cron job that periodically check if a new version is available online. If so, it automatically creates a Pull Request with all changes being automatically comitted for you.

This Pull Request is tested on different OS (centos, fedora 25, fedora 26) by creating an RPM, installing it, starting tomcat and finally curl it to check the http status code is 200

If the Pull Request looks ok, the only thing to do is to merge it and create a tag, then Copr will create the new RPM.

What do you think of this feature ?

If you like it, you will need to create a travis account and configure:
* a cron job on branch tomcat-8.5.x
* environment variables GITHUB_USER=csutherl and GITHUB_TOKEN [Personal access tokens](https://github.com/blog/1509-personal-api-tokens)

![image](https://user-images.githubusercontent.com/295554/32363620-8aa3f490-c070-11e7-92a9-0e0a3ecdfcc3.png)

You can take a look at this Pull Request as an example of what will be done automatically: https://github.com/scl-tomcat/tomcat-dev-rpm/pull/9

The next thing I would like to do is to provide different major version of tomcat (7, 8, 8.5, 9) on the same OS. Are you ok if I create an other Pull Request to add SCL to this project ?

Cheers
Romain